### PR TITLE
Adding verified to StripeRecipient

### DIFF
--- a/src/Stripe/Entities/StripeRecipient.cs
+++ b/src/Stripe/Entities/StripeRecipient.cs
@@ -38,6 +38,9 @@ namespace Stripe
         [JsonProperty("cards")]
         public StripeCardList StripeCardList { get; set; }
 
+        [JsonProperty("verified")]
+        public bool Verified { get; set; }
+
         public string StripeDefaultCardId { get; set; }
         public StripeCard StripeDefaultCard { get; set; }
 


### PR DESCRIPTION
Note: "Verified" is not explicitly mentioned in https://stripe.com/docs/api/curl#recipient_object, but appears in examples and mentioned in https://stripe.com/docs/testing.